### PR TITLE
setting up sysconfig file to set db connection info

### DIFF
--- a/hpfeeds-broker.run
+++ b/hpfeeds-broker.run
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-exec /usr/bin/env python /opt/hpfeeds/broker/feedbroker.py

--- a/hpfeeds-broker.run.j2
+++ b/hpfeeds-broker.run.j2
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+source {{ sysconfig_dir }}/hpfeeds
+
+if [[ -z $MONGOIP ]]
+then
+  MONGOIP='127.0.0.1'
+fi
+
+if [[ -z $MONGOPORT ]]
+then
+  MONGOPORT=27017
+fi
+
+# We can't really do anything but find/replace, or we have to fork upstream
+sed -i "s/MONGOIP = .*/MONGOIP = '${MONGOIP}'/" /opt/hpfeeds/broker/feedbroker.py
+sed -i "s/MONGOPORT = .*/MONGOPORT = ${MONGOPORT}/" /opt/hpfeeds/broker/feedbroker.py
+
+echo "Starting hpfeeds..."
+echo "MONGOPIP = ${MONGOIP}"
+echo "MONGOPPORT = ${MONGOPORT}"
+
+exec /usr/bin/env python /opt/hpfeeds/broker/feedbroker.py

--- a/hpfeeds.sysconfig
+++ b/hpfeeds.sysconfig
@@ -1,0 +1,8 @@
+# This file is read from /etc/sysconfig/hpfeeds 
+# or /etc/default/hpfeeds, depending on the distro version
+#
+# Defaults here are for containers, but can be adjusted 
+# after install for a regular server or to customize the containers
+
+MONGOIP='mongodb'
+MONGOPORT=27017

--- a/hpfeeds.yml
+++ b/hpfeeds.yml
@@ -50,7 +50,13 @@
           executable: "{{ pip_executable }}"
         with_items: "{{ hpfeeds_pip_pkgs_editable }}"
 
-      # Then pip install local hpfeedsdir
+      # Then pip install local hpfeedsdir?
+
+      - name: HPFeeds | copy sysconfig file
+        copy:
+          src: hpfeeds.sysconfig
+          dest: "{{ sysconfig_dir }}/hpfeeds"
+          mode: 0644
 
       - name: HPFeeds | install Runit
         yum:
@@ -65,8 +71,8 @@
           mode: 0755
 
       - name: HPFeeds | copy runit runfile
-        copy:
-          src: hpfeeds-broker.run
+        template:
+          src: hpfeeds-broker.run.j2
           dest: /etc/service/hpfeeds/run
           owner: root
           group: root

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -6,3 +6,5 @@
     - libev-devel
 
   runit_rpm_src: https://github.com/CommunityHoneyNetwork/rpmbuilder-runit/releases/download/2.1.2-1/runit-2.1.2-1.el7.centos.x86_64.rpm
+
+  sysconfig_dir: /etc/sysconfig

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -5,3 +5,5 @@
     - libev4
     - libev-dev
     - runit
+
+  sysconfig_dir: /etc/default


### PR DESCRIPTION
Since feedbroker.py from upstream has hard-coded database info, and we may not be running that db on a local setup, changed the hpfeeds init to parse an /etc/sysconfig or /etc/default file for database connection information, so we don't have to fork or otherwise maintain the feedbroker code.  

Probably need to adjust to encrypt transactions in the next iteration, in case these end up being run on separate hosts entirely.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>