### PR TITLE
Change evnet repo url

### DIFF
--- a/vars/default.yml
+++ b/vars/default.yml
@@ -15,6 +15,6 @@
     - pymongo
 
   hpfeeds_pip_pkgs_editable:
-    - git+https://github.com/rep/evnet.git#egg=evnet-dev
+    - git+https://github.com/CommunityHoneyNetwork/evnet.git#egg=evnet-dev
 
   broker_dir: /opt/hpfeeds/broker


### PR DESCRIPTION
Change to our own forked version of evnet repo, due to inactivity upstream.

Fixes #10 